### PR TITLE
refactor: 가독성 및 구조 개선

### DIFF
--- a/aws/image.go
+++ b/aws/image.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	a "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/spf13/viper"
 )
 
@@ -14,10 +12,10 @@ func (aws Aws) ListImages() error {
 	fmt.Println("list images")
 	input := &ec2.DescribeImagesInput{
 		Owners: []string{viper.GetString("AWS_OWNER_ID")},
-		Filters: []types.Filter{
-			{Name: a.String("name"),
-				Values: []string{"htcondor-worker"}},
-		},
+		// Filters: []types.Filter{
+		// 	{Name: a.String("name"),
+		// 		Values: []string{"htcondor-worker"}},
+		// },
 	}
 
 	images, err := aws.ec2.DescribeImages(context.TODO(), input)

--- a/aws/instance.go
+++ b/aws/instance.go
@@ -43,17 +43,19 @@ func (aws Aws) ListInstances() error {
 
 	return nil
 }
-func (aws Aws) StopInstance(id string, dryRun bool) error {
-	_, err := aws.ec2.StopInstances(context.TODO(), &ec2.StopInstancesInput{
-		DryRun:      ToBool(dryRun),
-		InstanceIds: []string{id},
-	})
+func (aws Aws) StopInstance(id string) error {
+	//DryRun : 요청 유효성 및 잠재적인 오류 확인
+	err := aws.stopInstance(id, true)
 	if err != nil {
-		if dryRun && strings.Contains(err.Error(), "DryRunOperation") {
-			return nil
-		}
 		return err
 	}
+	//Run
+	err = aws.stopInstance(id, false)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Successfully stop instance %s\n", id)
+
 	return nil
 }
 func (aws Aws) CreateInstance(id string) error {
@@ -72,11 +74,40 @@ func (aws Aws) CreateInstance(id string) error {
 		*res.ReservationId, id)
 	return nil
 }
-func (aws Aws) RebootInstance() {
-	fmt.Println("reboot instance")
+func (aws Aws) RebootInstance(id string, dryRun bool) error {
+
+	return nil
 }
-func (aws Aws) StartInstance(id string, dryRun bool) error {
+func (aws Aws) StartInstance(id string) error {
+	//DryRun : 요청 유효성 및 잠재적인 오류 확인
+	err := aws.startInstance(id, true)
+	if err != nil {
+		return err
+	}
+	//Run
+	err = aws.startInstance(id, false)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Successfully start instance %s\n", id)
+
+	return nil
+}
+func (aws Aws) startInstance(id string, dryRun bool) error {
 	_, err := aws.ec2.StartInstances(context.TODO(), &ec2.StartInstancesInput{
+		DryRun:      ToBool(dryRun),
+		InstanceIds: []string{id},
+	})
+	if err != nil {
+		if dryRun && strings.Contains(err.Error(), "DryRunOperation") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+func (aws Aws) stopInstance(id string, dryRun bool) error {
+	_, err := aws.ec2.StopInstances(context.TODO(), &ec2.StopInstancesInput{
 		DryRun:      ToBool(dryRun),
 		InstanceIds: []string{id},
 	})

--- a/internal/cli.go
+++ b/internal/cli.go
@@ -47,38 +47,18 @@ func (cli Cli) processAnswer(aws *aws.Aws) {
 	case startInstance:
 		fmt.Println("Enter instance id: ")
 		id := cli.scanString()
-		//DryRun : 요청 유효성 및 잠재적인 오류 확인
-		err := aws.StartInstance(id, true)
+		err := aws.StartInstance(id)
 		if err != nil {
 			log.Println(err)
-		}
-		//Run
-		if err == nil {
-			err = aws.StartInstance(id, false)
-			if err != nil {
-				log.Println(err)
-			} else {
-				fmt.Printf("Successfully start instance %s\n", id)
-			}
 		}
 	case availableRegions:
 		aws.AvailableRegions()
 	case stopInstance:
 		fmt.Println("Enter instance id: ")
 		id := cli.scanString()
-		//DryRun : 요청 유효성 및 잠재적인 오류 확인
-		err := aws.StopInstance(id, true)
+		err := aws.StopInstance(id)
 		if err != nil {
 			log.Println(err)
-		}
-		//Run
-		if err == nil {
-			err = aws.StopInstance(id, false)
-			if err != nil {
-				log.Println(err)
-			} else {
-				fmt.Printf("Successfully stop instance %s\n", id)
-			}
 		}
 	case createInstance:
 		fmt.Println("Enter ami id: ")
@@ -88,7 +68,22 @@ func (cli Cli) processAnswer(aws *aws.Aws) {
 			log.Println(err)
 		}
 	case rebootInstance:
-		aws.RebootInstance()
+		fmt.Println("Enter instance id: ")
+		id := cli.scanString()
+		//DryRun : 요청 유효성 및 잠재적인 오류 확인
+		err := aws.RebootInstance(id, true)
+		if err != nil {
+			log.Println(err)
+		}
+		//Run
+		if err == nil {
+			err = aws.RebootInstance(id, false)
+			if err != nil {
+				log.Println(err)
+			} else {
+				fmt.Printf("Successfully reboot instance %s\n", id)
+			}
+		}
 	case listImages:
 		aws.ListImages()
 	case quit:


### PR DESCRIPTION
## 개요
동일한 수준에서 결과를 출력하기 위해  stop & start 인스턴스 호출하는 구조 개선

## 결과

- 전
internal/cli.go에서 dryRun과 Run을 호출하여 cli.go에서 결과를 출력.


- 후 
aws/instance.go에서 dryRun과 Run을 호출하게 해서 다른 기능들과 동일하게 instance.go파일에서 결과를 출력.
