### PR TITLE
refactor: menu->page번호 순으로 테이블 구성

### DIFF
--- a/aws/info.go
+++ b/aws/info.go
@@ -35,3 +35,17 @@ func (aws Aws) AvailableRegions() ([]table.Row, error) {
 
 	return rows, nil
 }
+
+// func (aws Aws) ListSecurityGroup() ([]table.Row, error) {
+// 	sgs, err := aws.ec2.GetSecurityGroupsForVpc(context.TODO(), &ec2.GetSecurityGroupsForVpcInput{})
+
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	var rows []table.Row
+// 	for _, sg := range sgs.SecurityGroupForVpcs {
+// 		rows = append(rows, table.Row{*sg.GroupId, *sg.GroupName})
+// 	}
+// 	return rows, nil
+// }

--- a/aws/instance.go
+++ b/aws/instance.go
@@ -59,26 +59,26 @@ func (aws Aws) ListInstances(state *string) ([]table.Row, error) {
 
 	return rows, nil
 }
-func (aws Aws) StopInstance(id string) (*string, error) {
+func (aws Aws) StopInstance(ch []string) (*string, error) {
 	//DryRun : 요청 유효성 및 잠재적인 오류 확인
-	err := aws.stopInstance(id, true)
+	err := aws.stopInstance(ch[0], true)
 	if err != nil {
 		return nil, err
 	}
 	//Run
-	err = aws.stopInstance(id, false)
+	err = aws.stopInstance(ch[0], false)
 	if err != nil {
 		return nil, err
 	}
-	res := fmt.Sprintf("Successfully stop instance %s\n", id)
+	res := fmt.Sprintf("Successfully stop instance %s\n", ch[0])
 
 	return ptr(res), nil
 }
-func (aws Aws) CreateInstance(id string) (*string, error) {
+func (aws Aws) CreateInstance(ch []string) (*string, error) {
 	instanceOutput, err := aws.ec2.RunInstances(context.TODO(), &ec2.RunInstancesInput{
 		MaxCount:     ToInt32(1),
 		MinCount:     ToInt32(1),
-		ImageId:      ToString(id),
+		ImageId:      ToString(ch[0]),
 		InstanceType: types.InstanceTypeT2Micro,
 	})
 	if err != nil {
@@ -86,39 +86,39 @@ func (aws Aws) CreateInstance(id string) (*string, error) {
 	}
 
 	res := fmt.Sprintf("Successfully started EC2 instance %s based on AMI %s\n",
-		*instanceOutput.ReservationId, id)
+		*instanceOutput.ReservationId, ch[0])
 	return ptr(res), nil
 }
-func (aws Aws) RebootInstance(id string) (*string, error) {
+func (aws Aws) RebootInstance(ch []string) (*string, error) {
 	// DryRun : 요청 유효성 및 잠재적인 오류 확인
-	err := aws.rebootInstance(id, true)
+	err := aws.rebootInstance(ch[0], true)
 	if err != nil {
 		return nil, err
 	}
 	// Run
-	err = aws.rebootInstance(id, false)
+	err = aws.rebootInstance(ch[0], false)
 	if err != nil {
 		return nil, err
 	}
-	res := fmt.Sprintf("Successfully reboot instance %s\n", id)
+	res := fmt.Sprintf("Successfully reboot instance %s\n", ch[0])
 	return ptr(res), nil
 }
-func (aws Aws) StartInstance(id string) (*string, error) {
+func (aws Aws) StartInstance(ch []string) (*string, error) {
 	//DryRun : 요청 유효성 및 잠재적인 오류 확인
-	err := aws.startInstance(id, true)
+	err := aws.startInstance(ch[0], true)
 	if err != nil {
 		return nil, err
 	}
 	//Run
-	err = aws.startInstance(id, false)
+	err = aws.startInstance(ch[0], false)
 	if err != nil {
 		return nil, err
 	}
-	res := fmt.Sprintf("Successfully start instance %s\n", id)
+	res := fmt.Sprintf("Successfully start instance %s\n", ch[0])
 
 	return ptr(res), nil
 }
-func (aws Aws) ConnectInstance(host string) (*ssh.Client, error) {
+func (aws Aws) ConnectInstance(ch []string) (*ssh.Client, error) {
 	privateKeyPath := viper.GetString("PRIVATE_KEY_PATH")
 	user := viper.GetString("USER")
 	key, err := os.ReadFile(privateKeyPath)
@@ -138,7 +138,7 @@ func (aws Aws) ConnectInstance(host string) (*ssh.Client, error) {
 		Timeout:         15 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	conn, err := ssh.Dial("tcp", host+":22", config)
+	conn, err := ssh.Dial("tcp", ch[0]+":22", config)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/table.go
+++ b/internal/table.go
@@ -18,7 +18,9 @@ func (cli *Cli) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c":
 			return cli, tea.Quit
 		case "m", "M":
+			cli.page = 0
 			cli.menu = option(main)
+			cli.ch = []string{}
 			cli.table = NewTable(menuColumns, menuRows)
 		case "enter":
 			if cli.menu == main { //main menu
@@ -34,13 +36,27 @@ func (cli *Cli) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					cli.processAnswer(selected)
 				}
-			} else if cli.menu != listInstance &&
-				cli.menu != listImages &&
-				cli.menu != availableRegions &&
-				cli.menu != availableZones {
-				cli.ch = ptr(cli.table.SelectedRow()[0])
+			} else if cli.menu == createInstance {
+				switch cli.page {
+				// case 1:
+				// 	cli.ch = append(cli.ch, cli.table.SelectedRow()[0])
+				// 	cli.updateListSg(cli.menu)
+				case 1:
+					cli.ch = append(cli.ch, cli.table.SelectedRow()[0])
+					cli.processAnswer(cli.menu)
+				}
+			} else if cli.menu == connectInstance {
+				switch cli.page {
+				case 1:
+					cli.ch = append(cli.ch, cli.table.SelectedRow()[5])
+					cli.processAnswer(cli.menu)
+					return cli, tea.Batch(tea.ClearScreen)
+				}
+			} else if cli.menu == startInstance ||
+				cli.menu == stopInstance ||
+				cli.menu == rebootInstance {
+				cli.ch = append(cli.ch, cli.table.SelectedRow()[0])
 				cli.processAnswer(cli.menu)
-				clearScreen()
 			}
 		}
 	case tea.MouseMsg:
@@ -59,8 +75,8 @@ func (cli *Cli) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (cli *Cli) View() string {
-	if cli.ch != nil {
-		return baseStyle.Render(cli.table.View()) + "\n" + cli.table.HelpView() + "\n" + *cli.ch
+	if len(cli.ch) > 0 {
+		return baseStyle.Render(cli.table.View()) + "\n" + cli.table.HelpView() + "\n" + cli.ch[0]
 	}
 	return baseStyle.Render(cli.table.View()) + "\n" + cli.table.HelpView()
 }

--- a/internal/table_menu.go
+++ b/internal/table_menu.go
@@ -6,17 +6,18 @@ import (
 )
 
 const (
-	main             option = "0"
-	listInstance     option = "1"
-	availableZones   option = "2"
-	startInstance    option = "3"
-	availableRegions option = "4"
-	stopInstance     option = "5"
-	createInstance   option = "6"
-	rebootInstance   option = "7"
-	listImages       option = "8"
-	connectInstance  option = "9"
-	quit             option = "99"
+	main               option = "0"
+	listInstance       option = "1"
+	availableZones     option = "2"
+	startInstance      option = "3"
+	availableRegions   option = "4"
+	stopInstance       option = "5"
+	createInstance     option = "6"
+	rebootInstance     option = "7"
+	listImages         option = "8"
+	connectInstance    option = "9"
+	listSecurityGroups option = "10"
+	quit               option = "99"
 )
 
 var (
@@ -49,6 +50,10 @@ var (
 	regionColumns = []table.Column{
 		{Title: "region", Width: 20},
 		{Title: "endpoint", Width: 35},
+	}
+	sgColumns = []table.Column{
+		{Title: "id", Width: 15},
+		{Title: "name", Width: 10},
 	}
 	menuRows = []table.Row{
 		{"1", "list instance", "Print all states of an instance"},

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,8 +2,6 @@ package internal
 
 import (
 	"log"
-	"os"
-	"os/exec"
 )
 
 func handleResult(res *string, err error) *string {
@@ -21,8 +19,8 @@ func ptr(s string) *string {
 	return &s
 }
 
-func clearScreen() {
-	cmd := exec.Command("clear")
-	cmd.Stdout = os.Stdout
-	cmd.Run()
-}
+// func clearScreen() {
+// 	cmd := exec.Command("clear")
+// 	cmd.Stdout = os.Stdout
+// 	cmd.Run()
+// }


### PR DESCRIPTION
## 개요
```
type Cli struct {
	aws   aws.Aws
	table table.Model
	shell *shell
	ch    []string
	menu  option
	page  int
}
```
- cli.menu로만 메뉴들을 관리했었는데 메뉴안에 메뉴를 구성하고 선택지를 받아야하는 경우가 생기면서 문제가 발생하였다.
- 따라서 cli.page를 추가하여 처음 main menu선택 후 그 뒤의 메뉴들은 page번호로 관리한다.