### PR TITLE
fix : terminate instance error 출력 시 table이 깨지는 것 수정

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,12 +1,8 @@
 package internal
 
-import (
-	"log"
-)
-
 func handleResult(res *string, err error) *string {
 	if err != nil {
-		log.Println(err)
+		// log.Println(err)
 		return ptr(err.Error())
 	}
 	if res != nil {


### PR DESCRIPTION
## 개요
terminate instance error 출력 시 table 깨지는 것 수정
